### PR TITLE
Fixes Charged Porter

### DIFF
--- a/src/main/java/mcjty/rftools/items/teleportprobe/ChargedPorterItem.java
+++ b/src/main/java/mcjty/rftools/items/teleportprobe/ChargedPorterItem.java
@@ -206,7 +206,7 @@ public class ChargedPorterItem extends GenericRFToolsItem implements IEnergyItem
             BlockPos playerCoordinate = new BlockPos((int) player.posX, (int) player.posY, (int) player.posZ);
             int cost = TeleportationTools.calculateRFCost(world, playerCoordinate, destination);
             cost *= 1.5f;
-            int energy = getEnergyStored(stack);
+            int energy = getEnergyStoredL(stack);
             if (cost > energy) {
                 Logging.message(player, TextFormatting.RED + "Not enough energy to start the teleportation!");
                 return;


### PR DESCRIPTION
It is currently failing to find getEnergyStored on use, because the name now has an L at the end =)
Not 100% sure this is the only fix needed, but this is what's failing for me now