### PR TITLE
Categorzation fixes: rftools manuals

### DIFF
--- a/src/main/java/mcjty/rftools/blocks/storage/ModularStorageConfiguration.java
+++ b/src/main/java/mcjty/rftools/blocks/storage/ModularStorageConfiguration.java
@@ -255,7 +255,7 @@ public class ModularStorageConfiguration {
         categoryMapper.put("mcjty.rftools.items.teleportprobe.ChargedPorterItem", "Technical");
         categoryMapper.put("mcjty.rftools.items.manual.RFToolsManualItem", "Books");
         categoryMapper.put("mcjty.rftools.items.manual.RFToolsShapeManualItem", "Books");
-        categoryMapper.put("mcjty.rftools.items.manual.RFToolsManualDimensionItem", "Books");
+        categoryMapper.put("mcjty.rftools.items.manual.RFToolsDimensionManualItem", "Books");
         categoryMapper.put("mcjty.rftools.items.devdelight.DevelopersDelightItem", "Technical");
         categoryMapper.put("mcjty.rftools.items.dimlets.DimletTemplate", "Dimlets");
         categoryMapper.put("mcjty.rftools.items.dimlets.EmptyDimensionTab", "Dimlets");

--- a/src/main/java/mcjty/rftools/blocks/storage/ModularStorageConfiguration.java
+++ b/src/main/java/mcjty/rftools/blocks/storage/ModularStorageConfiguration.java
@@ -254,6 +254,7 @@ public class ModularStorageConfiguration {
         categoryMapper.put("mcjty.rftools.items.teleportprobe.TeleportProbeItem", "Technical");
         categoryMapper.put("mcjty.rftools.items.teleportprobe.ChargedPorterItem", "Technical");
         categoryMapper.put("mcjty.rftools.items.manual.RFToolsManualItem", "Books");
+        categoryMapper.put("mcjty.rftools.items.manual.RFToolsShapeManualItem", "Books");
         categoryMapper.put("mcjty.rftools.items.manual.RFToolsManualDimensionItem", "Books");
         categoryMapper.put("mcjty.rftools.items.devdelight.DevelopersDelightItem", "Technical");
         categoryMapper.put("mcjty.rftools.items.dimlets.DimletTemplate", "Dimlets");


### PR DESCRIPTION
The Shapes manual was absent, and the DimensionManual didn't make it through a rename, it looks like.

Thanks!

Is there an easy way to see these qualified class names in game? Would love to add more categorization for other mods easily